### PR TITLE
BartR java keyvault quickstart

### DIFF
--- a/articles/key-vault/quick-create-java.md
+++ b/articles/key-vault/quick-create-java.md
@@ -28,21 +28,22 @@ Azure Key Vault helps safeguard cryptographic keys and secrets used by cloud app
 - An Azure subscription - [create one for free](https://azure.microsoft.com/free/?WT.mc_id=A261C142F).
 - [Java Development Kit (JDK)](/java/azure/jdk/?view=azure-java-stable) version 8 or above
 - [Apache Maven](https://maven.apache.org)
-- [Azure CLI](/cli/azure/install-azure-cli?view=azure-cli-latest) or [Azure PowerShell](/powershell/azure/overview)
+- [Azure CLI](/cli/azure/install-azure-cli?view=azure-cli-latest)
 
 This quickstart assumes you are running [Azure CLI](/cli/azure/install-azure-cli?view=azure-cli-latest), [Apache Maven](https://maven.apache.org) and bash in a Linux terminal window.
 
 ## Setting up
 
-### Create new Java console app
+### Create a new Java console app
 
 In a console window, use the `mvn` command to create a new Java console app with the name `akv-java`.
 
-```console
-mvn archetype:generate -DgroupId=com.keyvault.quickstart
-                       -DartifactId=akv-java
-                       -DarchetypeArtifactId=maven-archetype-quickstart
-                       -DarchetypeVersion=1.4
+```bash
+mvn archetype:generate -DgroupId=com.keyvault.quickstart \
+                       -DartifactId=akv-java \
+                       -DarchetypeArtifactId=maven-archetype-quickstart \
+                       -DarchetypeVersion=1.4 \
+                       -Dversion=0.1.0 \
                        -DinteractiveMode=false
 ```
 
@@ -70,27 +71,27 @@ The output from generating the project will look something like this:
 [INFO] ------------------------------------------------------------------------
 ```
 
-Change your directory to the newly created akv-java/ folder.
+Change your directory to the newly created akv-java folder.
 
-```console
+```bash
 cd akv-java
 ```
 
-### Install the package
+### Install the packages
 
 Open the *pom.xml* file in your text editor. Add the following dependency elements to the group of dependencies.
 
 ```xml
     <dependency>
-      <groupId>com.azure</groupId>
-      <artifactId>azure-security-keyvault-secrets</artifactId>
-      <version>4.0.0</version>
+        <groupId>com.microsoft.azure</groupId>
+        <artifactId>azure-client-authentication</artifactId>
+      <version>1.7.2</version>
     </dependency>
 
     <dependency>
-      <groupId>com.azure</groupId>
-      <artifactId>azure-identity</artifactId>
-      <version>1.0.0</version>
+      <groupId>com.microsoft.azure</groupId>
+      <artifactId>azure-mgmt-keyvault</artifactId>
+      <version>1.31.0</version>
     </dependency>
 ```
 
@@ -99,70 +100,34 @@ Open the *pom.xml* file in your text editor. Add the following dependency elemen
 This quickstart uses a pre-created Azure key vault. You can create a key vault by following the steps in the [Azure CLI quickstart](quick-create-cli.md), [Azure PowerShell quickstart](quick-create-powershell.md), or [Azure portal quickstart](quick-create-portal.md). Alternatively, you can run the Azure CLI commands below.
 
 > [!Important]
-> Each key vault must have a unique name. Replace <your-unique-keyvault-name> with the name of your key vault in the following examples.
+> Each key vault must have a unique name. Replace `your-unique-keyvault-name` with the name of your key vault in the following examples.
 
-```azurecli
-az group create --name "myResourceGroup" -l "EastUS"
+```bash
 
-az keyvault create --name <your-unique-keyvault-name> -g "myResourceGroup"
+# your keyvault name must be unique
+export jkv_Name=your-unique-keyvault-name
+
+export jkv_RG=JavaKeyVaultQuickStart
+export jkv_Location=EastUS
+
+# create the resource group
+az group create -n $jkv_RG -l jkv_Location
+
+# create the key vault
+az keyvault create -n $jkv_Name -g jkv_RG
+
+# add a secret
+az keyvault secret set --vault-name $jkv_Name --name mySecret --value "Hello from Azure Key Vault!"
+
 ```
 
-### Create a service principal
+### Access Key Vault Securely
 
-The simplest way to authenticate a cloud-based application is with a managed identity; see [Use an App Service managed identity to access Azure Key Vault](managed-identity.md) for details. For the sake of simplicity however, this quickstart creates a desktop application, which requires the use of a service principal and an access control policy.
-
-Create a service principle using the Azure CLI [az ad sp create-for-rbac](/cli/azure/ad/sp?view=azure-cli-latest#az-ad-sp-create-for-rbac) command:
-
-```azurecli
-az ad sp create-for-rbac -n "http://mySP" --sdk-auth
-```
-
-This operation will return a series of key / value pairs.
-
-```console
-{
-  "clientId": "7da18cae-779c-41fc-992e-0527854c6583",
-  "clientSecret": "b421b443-1669-4cd7-b5b1-394d5c945002",
-  "subscriptionId": "443e30da-feca-47c4-b68f-1636b75e16b3",
-  "tenantId": "35ad10f1-7799-4766-9acf-f2d946161b77",
-  "activeDirectoryEndpointUrl": "https://login.microsoftonline.com",
-  "resourceManagerEndpointUrl": "https://management.azure.com/",
-  "activeDirectoryGraphResourceId": "https://graph.windows.net/",
-  "sqlManagementEndpointUrl": "https://management.core.windows.net:8443/",
-  "galleryEndpointUrl": "https://gallery.azure.com/",
-  "managementEndpointUrl": "https://management.core.windows.net/"
-}
-```
-
-Take note of the clientId, clientSecret, and tenantId, as we will use them in the next two steps.
-
-#### Give the service principal access to your key vault
-
-Create an access policy for your key vault that grants permission to your service principal by passing the clientId to the [az keyvault set-policy](/cli/azure/keyvault?view=azure-cli-latest#az-keyvault-set-policy) command. Give the service principal get, list, and set permissions for both keys and secrets.
-
-```azurecli
-az keyvault set-policy -n <your-unique-keyvault-name> --spn <clientId-of-your-service-principal> --secret-permissions delete get list set --key-permissions create decrypt delete encrypt get list unwrapKey wrapKey
-```
-
-#### Set environmental variables
-
-The DefaultAzureCredential method in our application relies on three environmental variables: `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, and `AZURE_TENANT_ID`. use set these variables to the clientId, clientSecret, and tenantId values you noted in the [Create a service principal](#create-a-service-principal) step, above. Use the `export VARNAME=VALUE` format to set your environmental variables. (This method only sets the variables for your current shell and processes created from the shell; to permanently add these variables to your environment, edit your `/etc/environment ` file.)
-
-You will also need to save your key vault name as an environment variable called `KEY_VAULT_NAME`.
-
-```console
-export AZURE_CLIENT_ID=<your-clientID>
-
-export AZURE_CLIENT_SECRET=<your-clientSecret>
-
-export AZURE_TENANT_ID=<your-tenantId>
-
-export KEY_VAULT_NAME=<your-key-vault-name>
-````
+The most secure way to authenticate a cloud-based application is with a managed identity; see [Use an App Service managed identity to access Azure Key Vault](managed-identity.md) for details. For the sake of simplicity, this quickstart creates a desktop application and uses the Azure CLI cached credentials to access Azure Key Vault.
 
 ## Object model
 
-The Azure Key Vault client library for Java allows you to manage keys and related assets such as certificates and secrets. The code samples below will show you how to create a client, set a secret, retrieve a secret, and delete a secret.
+The Azure Key Vault client library for Java allows you to manage keys and related assets such as certificates and secrets. The code samples below will show you how to read the secret we set earlier.
 
 The entire console app is [below](#sample-code).
 
@@ -173,141 +138,99 @@ The entire console app is [below](#sample-code).
 Add the following directives to the top of your code:
 
 ```java
-import com.azure.identity.DefaultAzureCredentialBuilder;
 
-import com.azure.security.keyvault.secrets.SecretClient;
-import com.azure.security.keyvault.secrets.SecretClientBuilder;
-import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
+import java.io.IOException;
+import com.microsoft.azure.credentials.*;
+import com.microsoft.azure.keyvault.*;
+import com.microsoft.azure.keyvault.models.*;
+
 ```
 
 ### Authenticate and create a client
 
-Authenticating to your key vault and creating a key vault client depends on the environmental variables in the [Set environmental variables](#set-environmental-variables) step above. The name of your key vault is expanded to the key vault URI, in the format `https://<your-key-vault-name>.vault.azure.net`.
+Authenticating to your key vault and creating a key vault client depends on the jkv_Name environment variable set in the [Create a resource group and key vault](#Create-a-resource-group-and-key-vault) step above. The name of your key vault is expanded to the key vault URL, in the format `https://<your-key-vault-name>.vault.azure.net`.
 
 ```java
-String keyVaultName = System.getenv("KEY_VAULT_NAME");
-String kvUri = "https://" + keyVaultName + ".vault.azure.net";
 
-SecretClient secretClient = new SecretClientBuilder()
-    .vaultUrl(kvUri)
-    .credential(new DefaultAzureCredentialBuilder().build())
-    .buildClient();
-```
+String keyVaultName = System.getenv("jkv_Name");
+String kvUri = "https://" + keyVaultName.trim() + ".vault.azure.net";
 
-### Save a secret
+AzureTokenCredentials cred = AzureCliCredentials.create();
+KeyVaultClient kvClient = new KeyVaultClient(cred);
 
-Now that your application is authenticated, you can put a secret into your keyvault using the `secretClient.setSecret` method. This requires a name for the secret -- we've assigned the value "mySecret" to the `secretName` variable in this sample.
-
-```java
-secretClient.setSecret(new KeyVaultSecret(secretName, secretValue));
-```
-
-You can verify that the secret has been set with the [az keyvault secret show](/cli/azure/keyvault/secret?view=azure-cli-latest#az-keyvault-secret-show) command:
-
-```azurecli
-az keyvault secret show --vault-name <your-unique-keyvault-name> --name mySecret
 ```
 
 ### Retrieve a secret
 
-You can now retrieve the previously set value with the `secretClient.getSecret` method.
+You can get `mySecret` set during setup with the `kvClient.getSecret` method.
 
 ```java
-KeyVaultSecret retrievedSecret = secretClient.getSecret(secretName);
+
+SecretBundle secret = kvClient.getSecret(kvUri, "mySecret");
+
+System.out.println(secret.value());
+
  ```
 
-You can now access the value of the retrieved secret with `retrievedSecret.getValue()`.
-
-### Delete a secret
-
-Finally, let's delete the secret from your key vault with the `secretClient.beginDeleteSecret` method.
-
-```java
-secretClient.beginDeleteSecret(secretName);
-```
-
-You can verify that the secret is gone with the [az keyvault secret show](/cli/azure/keyvault/secret?view=azure-cli-latest#az-keyvault-secret-show) command:
-
-```azurecli
-az keyvault secret show --vault-name <your-unique-keyvault-name> --name mySecret
-```
+You can access the value of the secret with `secret.value()`.
 
 ## Clean up resources
 
-When no longer needed, you can use the Azure CLI or Azure PowerShell to remove your key vault and the corresponding  resource group.
+When no longer needed, you can use the Azure CLI to remove your key vault and the corresponding resource group.
 
-```azurecli
-az group delete -g "myResourceGroup"
-```
+### Make sure there is nothing else in the resource group as it will be deleted
 
-```azurepowershell
-Remove-AzResourceGroup -Name "myResourceGroup"
+```bash
+
+az group delete -g $jkv_RG
+
 ```
 
 ## Sample code
 
 ```java
+
 package com.keyvault.quickstart;
 
-import java.io.Console;
-
-import com.azure.identity.DefaultAzureCredentialBuilder;
-
-import com.azure.security.keyvault.secrets.SecretClient;
-import com.azure.security.keyvault.secrets.SecretClientBuilder;
-import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
+import java.io.IOException;
+import com.microsoft.azure.credentials.*;
+import com.microsoft.azure.keyvault.*;
+import com.microsoft.azure.keyvault.models.*;
 
 public class App {
 
     public static void main(String[] args) throws InterruptedException, IllegalArgumentException {
 
-        String keyVaultName = System.getenv("KEY_VAULT_NAME");
-        String kvUri = "https://" + keyVaultName + ".vault.azure.net";
+        String keyVaultName = System.getenv("jkv_Name");
 
-        System.out.printf("key vault name = %s and kv uri = %s \n", keyVaultName, kvUri);
+        if (keyVaultName == null || keyVaultName.isBlank()) {
+            System.out.println("Set the jkv_Name environment variable");
+            System.exit(-1);
+        }
 
-        SecretClient secretClient = new SecretClientBuilder()
-            .vaultUrl(kvUri)
-            .credential(new DefaultAzureCredentialBuilder().build())
-            .buildClient();
+        String kvUri = "https://" + keyVaultName.trim() + ".vault.azure.net";
 
+        try {
+            // uses the Azure CLI credentials
+            AzureTokenCredentials cred = AzureCliCredentials.create();
 
-        Console con = System.console();
+            KeyVaultClient kvClient = new KeyVaultClient(cred);
 
-        String secretName = "mySecret";
+            SecretBundle secret = kvClient.getSecret(kvUri, "mySecret");
 
-        System.out.println("Input the value of your secret > ");
-        String secretValue = con.readLine();
+            System.out.println(secret.value());
 
-        System.out.print("Creating a secret in " + keyVaultName + " called '" + secretName + "' with the value '" + secretValue + "` ... ");
-
-        secretClient.setSecret(new KeyVaultSecret(secretName, secretValue));
-
-        System.out.println("done.");
-
-        System.out.println("Forgetting your secret.");
-        secretValue = "";
-        System.out.println("Your secret is '" + secretValue + "'.");
-
-        System.out.println("Retrieving your secret from " + keyVaultName + ".");
-
-        KeyVaultSecret retrievedSecret = secretClient.getSecret(secretName);
-
-        System.out.println("Your secret is '" + retrievedSecret.getValue() + "'.");
-        System.out.print("Deleting your secret from " + keyVaultName + " ... ");
-
-        secretClient.beginDeleteSecret(secretName);
-
-        System.out.println("done.");
-
-
+        } catch (IOException ex) {
+            System.out.println(ex.getMessage());
+        }
     }
 }
+
 ```
 
 ## Next steps
 
-In this quickstart you created a key vault, stored a secret, and retrieved that secret. To learn more about Key Vault and how to integrate it with your applications, continue on to the articles below.
+In this quickstart you created a key vault, set a secret and retrieved that secret. To learn more about Key Vault and how to integrate it with your applications, continue on to the articles below.
 
 - Read an [Overview of Azure Key Vault](key-vault-overview.md)
 - See the [Azure Key Vault developer's guide](key-vault-developers-guide.md)

--- a/articles/key-vault/quick-create-java.md
+++ b/articles/key-vault/quick-create-java.md
@@ -30,7 +30,7 @@ Azure Key Vault helps safeguard cryptographic keys and secrets used by cloud app
 - [Apache Maven](https://maven.apache.org)
 - [Azure CLI](/cli/azure/install-azure-cli?view=azure-cli-latest) or [Azure PowerShell](/powershell/azure/overview)
 
-This quickstart assumes you are running [Azure CLI](/cli/azure/install-azure-cli?view=azure-cli-latest) and [Apache Maven](https://maven.apache.org) in a Linux terminal window.
+This quickstart assumes you are running [Azure CLI](/cli/azure/install-azure-cli?view=azure-cli-latest), [Apache Maven](https://maven.apache.org) and bash in a Linux terminal window.
 
 ## Setting up
 
@@ -117,7 +117,7 @@ Create a service principle using the Azure CLI [az ad sp create-for-rbac](/cli/a
 az ad sp create-for-rbac -n "http://mySP" --sdk-auth
 ```
 
-This operation will return a series of key / value pairs. 
+This operation will return a series of key / value pairs.
 
 ```console
 {
@@ -146,7 +146,7 @@ az keyvault set-policy -n <your-unique-keyvault-name> --spn <clientId-of-your-se
 
 #### Set environmental variables
 
-The DefaultAzureCredential method in our application relies on three environmental variables: `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, and `AZURE_TENANT_ID`. use set these variables to the clientId, clientSecret, and tenantId values you noted in the [Create a service principal](#create-a-service-principal) step, above. Use the `export VARNAME=VALUE` format to set your environmental variables. (This method only sets the variables for your current shell and processes created from the shell; to permanently add these variables to your environment, edit your `/etc/environment ` file.) 
+The DefaultAzureCredential method in our application relies on three environmental variables: `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, and `AZURE_TENANT_ID`. use set these variables to the clientId, clientSecret, and tenantId values you noted in the [Create a service principal](#create-a-service-principal) step, above. Use the `export VARNAME=VALUE` format to set your environmental variables. (This method only sets the variables for your current shell and processes created from the shell; to permanently add these variables to your environment, edit your `/etc/environment ` file.)
 
 You will also need to save your key vault name as an environment variable called `KEY_VAULT_NAME`.
 
@@ -196,7 +196,7 @@ SecretClient secretClient = new SecretClientBuilder()
 
 ### Save a secret
 
-Now that your application is authenticated, you can put a secret into your keyvault using the `secretClient.setSecret` method. This requires a name for the secret -- we've assigned the value "mySecret" to the `secretName` variable in this sample.  
+Now that your application is authenticated, you can put a secret into your keyvault using the `secretClient.setSecret` method. This requires a name for the secret -- we've assigned the value "mySecret" to the `secretName` variable in this sample.
 
 ```java
 secretClient.setSecret(new KeyVaultSecret(secretName, secretValue));
@@ -249,7 +249,7 @@ Remove-AzResourceGroup -Name "myResourceGroup"
 ```java
 package com.keyvault.quickstart;
 
-import java.io.Console;   
+import java.io.Console;
 
 import com.azure.identity.DefaultAzureCredentialBuilder;
 
@@ -272,7 +272,7 @@ public class App {
             .buildClient();
 
 
-        Console con = System.console();  
+        Console con = System.console();
 
         String secretName = "mySecret";
 

--- a/articles/key-vault/quick-create-java.md
+++ b/articles/key-vault/quick-create-java.md
@@ -39,7 +39,7 @@ Azure Key Vault helps safeguard cryptographic keys and secrets used by cloud app
 
 In a terminal, use the `mvn` command to create a new Java console app with the name `akv-java`.
 
-```bash
+```console
 mvn archetype:generate -DgroupId=com.keyvault.quickstart \
                        -DartifactId=akv-java \
                        -DarchetypeArtifactId=maven-archetype-quickstart \
@@ -74,7 +74,7 @@ The output from generating the project will look something like this:
 
 Change your directory to the newly created akv-java folder.
 
-```bash
+```console
 
 cd akv-java
 
@@ -91,7 +91,9 @@ cd akv-java
 
 ### Install the packages
 
-Open the *pom.xml* file in [Visual Studio Code](https://code.visualstudio.com/Download) (or your favorite text editor). Add the following dependency elements to the group of dependencies. Note that the slf4j-nop prevents warning messages and isn't part of the solution.
+Open the *pom.xml* file in [Visual Studio Code](https://code.visualstudio.com/Download) (or your favorite text editor). Add the following dependency elements to the group of dependencies.
+
+> Note that the slf4j-nop prevents warning messages and isn't part of the solution.
 
 ```xml
 
@@ -125,7 +127,7 @@ This quickstart includes basic commands to create an Azure key vault. More detai
 
 Windows Command Prompt Commands
 
-```powershell
+```console
 
 # your keyvault name must be unique
 set jqs_KeyVaultName=your-unique-keyvault-name
@@ -275,7 +277,7 @@ When no longer needed, you can use the Azure CLI to remove your key vault and th
 
 > Make sure there are no resources in the Resource Group you want to retain as they will be deleted!
 
-```bash
+```console
 
 ### Make sure there is nothing else in the resource group as it will be deleted
 az group delete -g $jqs_ResourceGroup

--- a/articles/key-vault/quick-create-java.md
+++ b/articles/key-vault/quick-create-java.md
@@ -31,7 +31,7 @@ Azure Key Vault helps safeguard cryptographic keys and secrets used by cloud app
 - [Azure CLI](/cli/azure/install-azure-cli?view=azure-cli-latest)
 - [Visual Studio Code](https://code.visualstudio.com/Download) (optional but recommended)
 
-> This quickstart assumes you are running [Azure CLI](/cli/azure/install-azure-cli?view=azure-cli-latest), [Apache Maven](https://maven.apache.org) and either bash or Windows command prompt in a terminal.
+> This quickstart assumes you are running [Azure CLI](/cli/azure/install-azure-cli?view=azure-cli-latest), [Apache Maven](https://maven.apache.org) and either bash or Windows command prompt in a terminal
 
 ## Setting up
 
@@ -99,7 +99,7 @@ cd akv-java
 
 ### Files we care about
 
-> Assumes starting from the akv-java directory
+Assumes starting from the akv-java directory
 
 - pom.xml
   - Maven project file
@@ -108,7 +108,8 @@ cd akv-java
 
 ### Install the packages
 
-Open the *pom.xml* file in [Visual Studio Code](https://code.visualstudio.com/Download) (or your favorite text editor). Add the following dependency elements to the group of dependencies.
+- Open `pom.xml` in [Visual Studio Code](https://code.visualstudio.com/Download) (or your favorite text editor)
+- Add the following dependency elements to the group of dependencies.
 
 > Note that the slf4j-nop prevents warning messages and isn't part of the solution
 
@@ -138,10 +139,11 @@ Open the *pom.xml* file in [Visual Studio Code](https://code.visualstudio.com/Do
 
 This quickstart includes basic commands to create an Azure key vault. More detailed instructions are available at [Azure CLI quickstart](quick-create-cli.md), [Azure PowerShell quickstart](quick-create-powershell.md), or [Azure portal quickstart](quick-create-portal.md)
 
-> [!Important]
-> Each key vault must have a unique name. Replace `your-unique-keyvault-name` with the name of your key vault in the following examples.
+> **Each key vault must have a unique name**
 >
-> If you get an error on the az keyvault create command, change the environment variable value and try again.
+> Replace `your-unique-keyvault-name` with the name of your key vault in the following examples
+>
+> If you get an error on the az keyvault create command, change the environment variable value and try again
 
 Windows Command Prompt Commands
 
@@ -193,112 +195,11 @@ az keyvault secret show --vault-name $jqs_KeyVaultName --name mySecret
 
 ```
 
-## Code excerpts
-
-The Azure Key Vault client library for Java allows you to manage secrets and related assets such as keys and certificates.
-
-The code excerpts below will show you how to read the secret we set earlier as well as set, read and delete a new secret.
-
-> The entire console app is [below](#sample-code)
-
-### Add directives
-
-Add the following directives to the top of your code:
-
-```java
-
-import com.microsoft.azure.credentials.*;
-import com.microsoft.azure.keyvault.*;
-import com.microsoft.azure.keyvault.models.*;
-import com.microsoft.azure.keyvault.requests.*;
-
-```
-
-### Access Key Vault securely
-
-The most secure way to authenticate a cloud-based application is with a managed identity; see [Use an App Service managed identity to access Azure Key Vault](managed-identity.md) for more details.
-
-> This quickstart supports using a Managed Identity or using the Azure CLI cached credentials to access Azure Key Vault securely
->
-> Once Managed Identity is setup and functioning, set the `jqs_AuthType` environment variable to `MSI` to use Managed Identity
-
-### Authenticate and create a client
-
-Authenticating to your key vault and creating a key vault client depends on the `jqs_KeyVaultName` environment variable set in the [initial setup](#Create-a-resource-group-and-key-vault) above.
-
-> The name of your key vault is expanded to the key vault URL, in the format `https://<your-key-vault-name>.vault.azure.net`
-
-```java
-
-// build the Key Vault URL from the env var
-String keyVaultName = System.getenv("jqs_KeyVaultName");
-String kvUri = "https://" + keyVaultName.trim() + ".vault.azure.net";
-
-AzureTokenCredentials cred = null;
-
-// check for jqs_AuthType env var
-String isMsi = System.getenv("jqs_AuthType");
-if (isMsi != null && isMsi.equals("MSI")) {
-    // use Managed Identity
-    cred = new MSICredentials(AzureEnvironment.AZURE);
-} else {
-    // use Azure CLI cache
-    cred = AzureCliCredentials.create();
-}
-
-```
-
-### Retrieve a secret
-
-You can get `mySecret` set during setup with the `kvClient.getSecret` method. You can access the value of the secret with `secret.value()`
-
-```java
-
-SecretBundle secret = kvClient.getSecret(kvUri, "mySecret");
-
-System.out.println(secret.value());
-
- ```
-
-### Create a secret
-
-You can create (set) `myNewSecret` using the `kvClient.setSecret` method after building the `SetSecretRequest`
-
-```java
-
-SetSecretRequest req = new SetSecretRequest.Builder(kvUrl, "myNewSecret", "My new secret value").build();
-kvClient.setSecret(req);
-
-
-```
-
-### Delete a secret
-
-You can delete `myNewSecret` using the `kvClient.deleteSecret` method
-
-```java
-
-kvClient.deleteSecret(kvUrl, "myNewSecret");
-
-```
-
-### Verify myNewSecret was deleted
-
-You can verify that `myNewSecret` was deleted using `kvClient.getSecret` and checking `secret == null`
-
-```java
-
-// myNewSecret should be null
-secret = kvClient.getSecret(kvUrl, "myNewSecret");
-System.out.println(secret == null);
-
-```
-
 ## Running the code
 
-Open src/main/java/com/keyvault/quickstart/App.java with VS Code and replace all contents with the code below.
+Open src/main/java/com/keyvault/quickstart/App.java with VS Code and replace all contents with the code below
 
-> Save and press F5 to run the code
+> Press F5 to run the code
 
 ```java
 
@@ -380,6 +281,115 @@ public class App {
         System.exit(0);
     }
 }
+
+```
+
+## Code excerpts
+
+The Azure Key Vault client library for Java allows you to manage secrets and related assets such as keys and certificates
+
+> The code excerpts below explain key concepts
+
+### Add directives
+
+Import the libraries added in `pom.xml`
+
+```java
+
+import com.microsoft.azure.AzureEnvironment;
+import com.microsoft.azure.credentials.*;
+import com.microsoft.azure.keyvault.*;
+import com.microsoft.azure.keyvault.models.*;
+import com.microsoft.azure.keyvault.requests.*;
+
+```
+
+### Access Key Vault securely
+
+The most secure way to authenticate a cloud-based application is with a managed identity; see [Use an App Service managed identity to access Azure Key Vault](managed-identity.md) for more details.
+
+> This quickstart supports using a Managed Identity or using the Azure CLI cached credentials to access Azure Key Vault securely
+>
+> Once Managed Identity is setup and functioning, set the `jqs_AuthType` environment variable to `MSI` to use Managed Identity
+
+```java
+
+AzureTokenCredentials cred = null;
+
+// check for jqs_AuthType env var
+String isMsi = System.getenv("jqs_AuthType");
+if (isMsi != null && isMsi.equals("MSI")) {
+    // use Managed Identity
+    cred = new MSICredentials(AzureEnvironment.AZURE);
+} else {
+    // use Azure CLI cache
+    cred = AzureCliCredentials.create();
+}
+
+```
+
+### Create the KeyVaultClient
+
+Creating a key vault client depends on the `jqs_KeyVaultName` environment variable set in the [initial setup](#Create-a-resource-group-and-key-vault) above.
+
+> The name of your key vault is expanded to the key vault URL, in the format `https://<your-key-vault-name>.vault.azure.net`
+
+```java
+
+// build the Key Vault URL from the env var
+String keyVaultName = System.getenv("jqs_KeyVaultName");
+String kvUri = "https://" + keyVaultName.trim() + ".vault.azure.net";
+
+// create Key Vault client
+KeyVaultClient kvClient = new KeyVaultClient(cred);
+
+```
+
+### Retrieve a secret
+
+You can get `mySecret` set during setup with the `kvClient.getSecret` method. You can access the value of the secret with `secret.value()`
+
+```java
+
+// get mySecret
+SecretBundle secret = kvClient.getSecret(kvUri, "mySecret");
+System.out.println(secret.value());
+
+ ```
+
+### Create a secret
+
+You can create (set) `myNewSecret` using the `kvClient.setSecret` method after building the `SetSecretRequest`
+
+```java
+
+// create myNewSecret
+SetSecretRequest req = new SetSecretRequest.Builder(kvUrl, "myNewSecret", "My new secret value").build();
+secret = kvClient.setSecret(req);
+
+```
+
+### Delete a secret
+
+You can delete `myNewSecret` using the `kvClient.deleteSecret` method
+
+```java
+
+// delete myNewSecret
+secret = kvClient.deleteSecret(kvUrl, "myNewSecret");
+System.out.println(secret.id());
+
+```
+
+### Verify myNewSecret was deleted
+
+You can verify that `myNewSecret` was deleted using `kvClient.getSecret` and checking `secret == null`
+
+```java
+
+// myNewSecret should be null
+secret = kvClient.getSecret(kvUrl, "myNewSecret");
+System.out.println(secret == null);
 
 ```
 

--- a/articles/key-vault/quick-create-java.md
+++ b/articles/key-vault/quick-create-java.md
@@ -82,17 +82,25 @@ cd akv-java
 Open the *pom.xml* file in your text editor. Add the following dependency elements to the group of dependencies.
 
 ```xml
-    <dependency>
-        <groupId>com.microsoft.azure</groupId>
-        <artifactId>azure-client-authentication</artifactId>
-      <version>1.7.2</version>
-    </dependency>
 
-    <dependency>
+  <dependency>
       <groupId>com.microsoft.azure</groupId>
-      <artifactId>azure-mgmt-keyvault</artifactId>
-      <version>1.31.0</version>
-    </dependency>
+      <artifactId>azure-client-authentication</artifactId>
+    <version>1.7.2</version>
+  </dependency>
+
+  <dependency>
+    <groupId>com.microsoft.azure</groupId>
+    <artifactId>azure-mgmt-keyvault</artifactId>
+    <version>1.31.0</version>
+  </dependency>
+
+  <dependency>
+    <groupId>org.slf4j</groupId>
+    <artifactId>slf4j-nop</artifactId>
+    <version>1.7.30</version>
+  </dependency>
+
 ```
 
 ### Create a resource group and key vault

--- a/articles/key-vault/quick-create-java.md
+++ b/articles/key-vault/quick-create-java.md
@@ -29,8 +29,9 @@ Azure Key Vault helps safeguard cryptographic keys and secrets used by cloud app
 - [Java Development Kit (JDK)](/java/azure/jdk/?view=azure-java-stable) version 8 or above
 - [Apache Maven](https://maven.apache.org)
 - [Azure CLI](/cli/azure/install-azure-cli?view=azure-cli-latest)
+- [Visual Studio Code](https://code.visualstudio.com/Download) (optional but recommended)
 
-This quickstart assumes you are running [Azure CLI](/cli/azure/install-azure-cli?view=azure-cli-latest), [Apache Maven](https://maven.apache.org) and either bash or Windows command prompt in a terminal.
+> This quickstart assumes you are running [Azure CLI](/cli/azure/install-azure-cli?view=azure-cli-latest), [Apache Maven](https://maven.apache.org) and either bash or Windows command prompt in a terminal.
 
 ## Setting up
 
@@ -79,9 +80,18 @@ cd akv-java
 
 ```
 
+### Files we care about
+
+> Assumes starting from the akv-java directory
+
+- pom.xml
+  - Maven project file
+- src/main/java/com/keyvault/quickstart/App.java
+  - Java source code
+
 ### Install the packages
 
-Open the *pom.xml* file in your text editor. Add the following dependency elements to the group of dependencies. Note that the slf4j-nop prevents warning messages and isn't part of the solution.
+Open the *pom.xml* file in [Visual Studio Code](https://code.visualstudio.com/Download) (or your favorite text editor). Add the following dependency elements to the group of dependencies. Note that the slf4j-nop prevents warning messages and isn't part of the solution.
 
 ```xml
 
@@ -184,7 +194,9 @@ import com.microsoft.azure.keyvault.requests.*;
 
 ### Access Key Vault securely
 
-The most secure way to authenticate a cloud-based application is with a managed identity; see [Use an App Service managed identity to access Azure Key Vault](managed-identity.md) for details. This quickstart supports using a Managed Identity or using the Azure CLI cached credentials to access Azure Key Vault securely.
+The most secure way to authenticate a cloud-based application is with a managed identity; see [Use an App Service managed identity to access Azure Key Vault](managed-identity.md) for details.
+
+> This quickstart supports using a Managed Identity or using the Azure CLI cached credentials to access Azure Key Vault securely.
 
 Once Managed Identity is setup and functioning, set the `jqs_AuthType` environment variable to `MSI` to use Managed Identity.
 
@@ -214,7 +226,7 @@ if (isMsi != null && isMsi.equals("MSI")) {
 
 ### Retrieve a secret
 
-You can get `mySecret` set during setup with the `kvClient.getSecret` method. You can access the value of the secret with `secret.value()`.
+You can get `mySecret` set during setup with the `kvClient.getSecret` method. You can access the value of the secret with `secret.value()`
 
 ```java
 
@@ -226,7 +238,7 @@ System.out.println(secret.value());
 
 ### Create a secret
 
-Create (set) myNewSecret
+You can create (set) `myNewSecret` using the `kvClient.setSecret` method after building the `SetSecretRequest`
 
 ```java
 
@@ -238,7 +250,7 @@ kvClient.setSecret(req);
 
 ### Delete a secret
 
-Delete myNewSecret
+You can delete `myNewSecret` using the `kvClient.deleteSecret` method
 
 ```java
 
@@ -246,9 +258,23 @@ kvClient.deleteSecret(kvUrl, "myNewSecret");
 
 ```
 
-## Clean up resources
+### Verify myNewSecret was deleted
+
+You can verify that `myNewSecret` was deleted using `kvClient.getSecret` and checking `secret == null`
+
+```java
+
+// myNewSecret should be null
+secret = kvClient.getSecret(kvUrl, "myNewSecret");
+System.out.println(secret == null);
+
+```
+
+## Delete Key Vault and Resource Group
 
 When no longer needed, you can use the Azure CLI to remove your key vault and the corresponding resource group.
+
+> Make sure there are no resources in the Resource Group you want to retain as they will be deleted!
 
 ```bash
 

--- a/articles/key-vault/quick-create-java.md
+++ b/articles/key-vault/quick-create-java.md
@@ -39,13 +39,30 @@ Azure Key Vault helps safeguard cryptographic keys and secrets used by cloud app
 
 In a terminal, use the `mvn` command to create a new Java console app with the name `akv-java`.
 
+Windows
+
 ```console
+
+mvn archetype:generate -DgroupId=com.keyvault.quickstart ^
+                       -DartifactId=akv-java ^
+                       -DarchetypeArtifactId=maven-archetype-quickstart ^
+                       -DarchetypeVersion=1.4 ^
+                       -Dversion=0.1.0 ^
+                       -DinteractiveMode=false
+
+```
+
+Bash
+
+```bash
+
 mvn archetype:generate -DgroupId=com.keyvault.quickstart \
                        -DartifactId=akv-java \
                        -DarchetypeArtifactId=maven-archetype-quickstart \
                        -DarchetypeVersion=1.4 \
                        -Dversion=0.1.0 \
                        -DinteractiveMode=false
+
 ```
 
 The output from generating the project will look something like this:
@@ -93,7 +110,7 @@ cd akv-java
 
 Open the *pom.xml* file in [Visual Studio Code](https://code.visualstudio.com/Download) (or your favorite text editor). Add the following dependency elements to the group of dependencies.
 
-> Note that the slf4j-nop prevents warning messages and isn't part of the solution.
+> Note that the slf4j-nop prevents warning messages and isn't part of the solution
 
 ```xml
 
@@ -119,10 +136,11 @@ Open the *pom.xml* file in [Visual Studio Code](https://code.visualstudio.com/Do
 
 ### Create a resource group and key vault
 
-This quickstart includes basic commands to create an Azure key vault. More detailed instructions are available at [Azure CLI quickstart](quick-create-cli.md), [Azure PowerShell quickstart](quick-create-powershell.md), or [Azure portal quickstart](quick-create-portal.md).
+This quickstart includes basic commands to create an Azure key vault. More detailed instructions are available at [Azure CLI quickstart](quick-create-cli.md), [Azure PowerShell quickstart](quick-create-powershell.md), or [Azure portal quickstart](quick-create-portal.md)
 
 > [!Important]
 > Each key vault must have a unique name. Replace `your-unique-keyvault-name` with the name of your key vault in the following examples.
+>
 > If you get an error on the az keyvault create command, change the environment variable value and try again.
 
 Windows Command Prompt Commands
@@ -177,9 +195,11 @@ az keyvault secret show --vault-name $jqs_KeyVaultName --name mySecret
 
 ## Code excerpts
 
-The Azure Key Vault client library for Java allows you to manage keys and related assets such as certificates and secrets. The code excerpts below will show you how to read the secret we set earlier as well as set, read and delete a new secret.
+The Azure Key Vault client library for Java allows you to manage secrets and related assets such as keys and certificates.
 
-The entire console app is [below](#sample-code).
+The code excerpts below will show you how to read the secret we set earlier as well as set, read and delete a new secret.
+
+> The entire console app is [below](#sample-code)
 
 ### Add directives
 
@@ -199,11 +219,14 @@ import com.microsoft.azure.keyvault.requests.*;
 The most secure way to authenticate a cloud-based application is with a managed identity; see [Use an App Service managed identity to access Azure Key Vault](managed-identity.md) for more details.
 
 > This quickstart supports using a Managed Identity or using the Azure CLI cached credentials to access Azure Key Vault securely
+>
 > Once Managed Identity is setup and functioning, set the `jqs_AuthType` environment variable to `MSI` to use Managed Identity
 
 ### Authenticate and create a client
 
-Authenticating to your key vault and creating a key vault client depends on the `jqs_KeyVaultName` environment variable set in the [initial setup](#Create-a-resource-group-and-key-vault) above. The name of your key vault is expanded to the key vault URL, in the format `https://<your-key-vault-name>.vault.azure.net`.
+Authenticating to your key vault and creating a key vault client depends on the `jqs_KeyVaultName` environment variable set in the [initial setup](#Create-a-resource-group-and-key-vault) above.
+
+> The name of your key vault is expanded to the key vault URL, in the format `https://<your-key-vault-name>.vault.azure.net`
 
 ```java
 
@@ -271,22 +294,11 @@ System.out.println(secret == null);
 
 ```
 
-## Delete Key Vault and Resource Group
+## Running the code
 
-When no longer needed, you can use the Azure CLI to remove your key vault and the corresponding resource group.
+Open src/main/java/com/keyvault/quickstart/App.java with VS Code and replace all contents with the code below.
 
-> Make sure there are no resources in the Resource Group you want to retain as they will be deleted!
-
-```console
-
-### Make sure there is nothing else in the resource group as it will be deleted
-az group delete -g $jqs_ResourceGroup
-
-```
-
-## Sample code
-
-Open src/main/java/com/keyvault/quickstart/App.java with VS Code and replace all contents with the code below. Save and press F5 to run the code.
+> Save and press F5 to run the code
 
 ```java
 
@@ -368,6 +380,19 @@ public class App {
         System.exit(0);
     }
 }
+
+```
+
+## Delete Key Vault and Resource Group
+
+When no longer needed, you can use the Azure CLI to remove your key vault and the corresponding resource group.
+
+> **Make sure there are no resources in the Resource Group you want to retain as they will be deleted!**
+
+```console
+
+### Make sure there is nothing else in the resource group as it will be deleted
+az group delete -g $jqs_ResourceGroup
 
 ```
 

--- a/articles/key-vault/quick-create-java.md
+++ b/articles/key-vault/quick-create-java.md
@@ -97,7 +97,7 @@ az keyvault secret show --vault-name $jqs_KeyVaultName --name mySecret
 
 In a terminal, use the `mvn` command to create a new Java console app with the name `akv-java`.
 
-### Windows
+### Windows Command
 
 ```console
 
@@ -110,7 +110,7 @@ mvn archetype:generate -DgroupId=com.keyvault.quickstart ^
 
 ```
 
-### Bash
+### Bash Command
 
 ```bash
 

--- a/articles/key-vault/quick-create-java.md
+++ b/articles/key-vault/quick-create-java.md
@@ -26,7 +26,7 @@ Azure Key Vault helps safeguard cryptographic keys and secrets used by cloud app
 ## Prerequisites
 
 - An Azure subscription - [create one for free](https://azure.microsoft.com/free/?WT.mc_id=A261C142F).
-- [Java Development Kit (JDK)](/java/azure/jdk/?view=azure-java-stable) version 8 or above
+- [Java Development Kit (JDK)](https://jdk.java.net/13/) version 13 or above
 - [Apache Maven](https://maven.apache.org)
 - [Azure CLI](/cli/azure/install-azure-cli?view=azure-cli-latest)
 - [Visual Studio Code](https://code.visualstudio.com/Download) (optional but recommended)

--- a/articles/key-vault/quick-create-java.md
+++ b/articles/key-vault/quick-create-java.md
@@ -216,7 +216,7 @@ public class App {
 
         String keyVaultName = System.getenv("jqs_KeyVaultName");
 
-        if (keyVaultName == null || keyVaultName.isBlank()) {
+        if (keyVaultName == null || keyVaultName.isEmpty()) {
             System.out.println("Set the jqs_KeyVaultName environment variable");
             System.exit(-1);
         }

--- a/articles/key-vault/quick-create-java.md
+++ b/articles/key-vault/quick-create-java.md
@@ -33,13 +33,71 @@ Azure Key Vault helps safeguard cryptographic keys and secrets used by cloud app
 
 > This quickstart assumes you are running [Azure CLI](/cli/azure/install-azure-cli?view=azure-cli-latest), [Apache Maven](https://maven.apache.org) and either bash or Windows command prompt in a terminal
 
-## Setting up
+## Create a resource group and key vault
 
-### Create a new Java console app
+This quickstart includes basic commands to create an Azure key vault. More detailed instructions are available at [Azure CLI quickstart](quick-create-cli.md), [Azure PowerShell quickstart](quick-create-powershell.md), or [Azure portal quickstart](quick-create-portal.md)
+
+> **Each key vault must have a unique name**
+>
+> Replace `your-unique-keyvault-name` with the name of your key vault in the following examples
+>
+> If you get an error on the az keyvault create command, change the environment variable value and try again
+
+### Windows
+
+```console
+
+# your keyvault name must be unique
+set jqs_KeyVaultName=your-unique-keyvault-name
+
+# you can change these if you want
+set jqs_ResourceGroup=JavaKeyVaultQuickStart
+set jqs_Location=EastUS
+
+# create the resource group
+az group create -n %jqs_ResourceGroup% -l %jqs_Location%
+
+# create the key vault
+az keyvault create -n %jqs_KeyVaultName% -g %jqs_ResourceGroup%
+
+# add a secret
+az keyvault secret set --vault-name %jqs_KeyVaultName% --name mySecret --value "Hello from Azure Key Vault!"
+
+# check the value
+az keyvault secret show --vault-name %jqs_KeyVaultName% --name mySecret
+
+```
+
+### Bash
+
+```bash
+
+# your keyvault name must be unique
+export jqs_KeyVaultName=your-unique-keyvault-name
+
+# you can change these if you want
+export jqs_ResourceGroup=JavaKeyVaultQuickStart
+export jqs_Location=EastUS
+
+# create the resource group
+az group create -n $jqs_ResourceGroup -l $jqs_Location
+
+# create the key vault
+az keyvault create -n $jqs_KeyVaultName -g $jqs_ResourceGroup
+
+# add a secret
+az keyvault secret set --vault-name $jqs_KeyVaultName --name mySecret --value "Hello from Azure Key Vault!"
+
+# check the value
+az keyvault secret show --vault-name $jqs_KeyVaultName --name mySecret
+
+```
+
+## Create a new Java console app
 
 In a terminal, use the `mvn` command to create a new Java console app with the name `akv-java`.
 
-Windows
+### Windows
 
 ```console
 
@@ -52,7 +110,7 @@ mvn archetype:generate -DgroupId=com.keyvault.quickstart ^
 
 ```
 
-Bash
+### Bash
 
 ```bash
 
@@ -97,7 +155,7 @@ cd akv-java
 
 ```
 
-### Files we care about
+## Files to change
 
 Assumes starting from the akv-java directory
 
@@ -106,7 +164,7 @@ Assumes starting from the akv-java directory
 - src/main/java/com/keyvault/quickstart/App.java
   - Java source code
 
-### Install the packages
+## Install the packages
 
 - Open `pom.xml` in [Visual Studio Code](https://code.visualstudio.com/Download) (or your favorite text editor)
 - Add the following dependency elements to the group of dependencies.
@@ -115,83 +173,23 @@ Assumes starting from the akv-java directory
 
 ```xml
 
-  <dependency>
-    <groupId>com.microsoft.azure</groupId>
-    <artifactId>azure-client-authentication</artifactId>
-    <version>1.7.2</version>
-  </dependency>
+    <dependency>
+      <groupId>com.microsoft.azure</groupId>
+      <artifactId>azure-client-authentication</artifactId>
+      <version>1.7.2</version>
+    </dependency>
 
-  <dependency>
-    <groupId>com.microsoft.azure</groupId>
-    <artifactId>azure-mgmt-keyvault</artifactId>
-    <version>1.31.0</version>
-  </dependency>
+    <dependency>
+      <groupId>com.microsoft.azure</groupId>
+      <artifactId>azure-mgmt-keyvault</artifactId>
+      <version>1.31.0</version>
+    </dependency>
 
-  <dependency>
-    <groupId>org.slf4j</groupId>
-    <artifactId>slf4j-nop</artifactId>
-    <version>1.7.30</version>
-  </dependency>
-
-```
-
-### Create a resource group and key vault
-
-This quickstart includes basic commands to create an Azure key vault. More detailed instructions are available at [Azure CLI quickstart](quick-create-cli.md), [Azure PowerShell quickstart](quick-create-powershell.md), or [Azure portal quickstart](quick-create-portal.md)
-
-> **Each key vault must have a unique name**
->
-> Replace `your-unique-keyvault-name` with the name of your key vault in the following examples
->
-> If you get an error on the az keyvault create command, change the environment variable value and try again
-
-Windows Command Prompt Commands
-
-```console
-
-# your keyvault name must be unique
-set jqs_KeyVaultName=your-unique-keyvault-name
-
-# you can change these if you want
-set jqs_ResourceGroup=JavaKeyVaultQuickStart
-set jqs_Location=EastUS
-
-# create the resource group
-az group create -n %jqs_ResourceGroup% -l %jqs_Location%
-
-# create the key vault
-az keyvault create -n %jqs_KeyVaultName% -g %jqs_ResourceGroup%
-
-# add a secret
-az keyvault secret set --vault-name %jqs_KeyVaultName% --name mySecret --value "Hello from Azure Key Vault!"
-
-# check the value
-az keyvault secret show --vault-name %jqs_KeyVaultName% --name mySecret
-
-```
-
-Bash Commands
-
-```bash
-
-# your keyvault name must be unique
-export jqs_KeyVaultName=your-unique-keyvault-name
-
-# you can change these if you want
-export jqs_ResourceGroup=JavaKeyVaultQuickStart
-export jqs_Location=EastUS
-
-# create the resource group
-az group create -n $jqs_ResourceGroup -l $jqs_Location
-
-# create the key vault
-az keyvault create -n $jqs_KeyVaultName -g $jqs_ResourceGroup
-
-# add a secret
-az keyvault secret set --vault-name $jqs_KeyVaultName --name mySecret --value "Hello from Azure Key Vault!"
-
-# check the value
-az keyvault secret show --vault-name $jqs_KeyVaultName --name mySecret
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-nop</artifactId>
+      <version>1.7.30</version>
+    </dependency>
 
 ```
 
@@ -401,7 +399,14 @@ When no longer needed, you can use the Azure CLI to remove your key vault and th
 
 ```console
 
-### Make sure there is nothing else in the resource group as it will be deleted
+## Make sure there are no resources in the Resource Group you want to retain as they will be deleted!
+
+
+## Windows
+az group delete -g %jqs_ResourceGroup%
+
+
+## bash
 az group delete -g $jqs_ResourceGroup
 
 ```

--- a/articles/key-vault/quick-create-java.md
+++ b/articles/key-vault/quick-create-java.md
@@ -3,7 +3,7 @@ title: Quickstart -  Azure Key Vault client library for Java
 description: Provides format and content criteria for writing Quickstarts for Azure SDK client libraries.
 author: msmbaldwin
 ms.author: mbaldwin
-ms.date: 10/20/2019
+ms.date: 02/25/2020
 ms.service: key-vault
 ms.topic: quickstart
 


### PR DESCRIPTION
## Please do not merge!!!

## I renamed the branch to follow the upstream naming standards

- Please step through the instructions to test
  - also time how long it takes beginning to end
    - record in a comment to this PR

## Purpose of PR

- Secure by Design
  - the existing quick start stores passwords in clear text
  - support Managed Identity for production
  - support AZ CLI credentials for Developer Experience
- Enterprise Friendly
  - the existing quick start requires creating a Service Principal
    - most enterprise developers don't have the necessary permissions

## Change Log

- Updated based on Joseph's comment
  - now supports bash and Windows command prompt for setup
- Renamed env var jqs_* (Java Quick Start)
  - per our doc standards
- Added the ability to use MSI or CLI cached credentials
  - from helium-java code
- Added some error checking, but it's not complete
  - I don't think it has to be for a quick start but open to adding more
- Added a link to VS Code and instructions to run via F5
- Need to add instructions for running from the command line
- Need to test again using Visual Studio Online
  - should we add VSO instructions? It seems to be the easiest way to start
  - can we get VSO to install Maven as part of the standard image?
    - it's a simple apt-get, so not a big deal but would be one less step
